### PR TITLE
Feature/save test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To update this repo, you will need write access to the General Mills public repo
 - [generate_schema_name](#generate_schema_name) [(source)](./macros/generate_schema_name.sql)
 - [smart_source](#smart_source) [(source)](./macros/smart_source.sql)
 - [materialized_views](#materialized_views) [(source)](./macros/bigquery)
+- [save_test_results](#save_test_results) [(source)](./macros/save_test_results.sql)
+   - uses helper macro [generate_schema_name](#generate_schema_name) [(source)](./macros/helpers/generate_schema_name.sql)
 
 
 ### Usage 
@@ -80,3 +82,17 @@ Materialized views are powerful but they can be costly, so please consult with t
       materialized_views: 
         +materialized: materialized_view
         +schema: output
+
+
+#### save_test_results
+This macro saves dbt data quality test results to a table in the target project's processed dataset: `processed.dbt_test_results`. This is an append-only table that associates each data quality check/result to a particular dbt run. For development runs (zdev), a separate results table will be created in the corresponding zdev processed dataset.
+
+Runs that are associated with a dbt Cloud job will be associated with their corresponding `DBT_CLOUD_RUN_ID`, while runs that were kicked off from the CLI are associated with their `invocation_id` (since they are not given a cloud run id).
+
+To use this macro within a project, include the following in the `dbt_project.yml`:
+```yml
+# SQL statements to be executed after the completion of a run, build, test, etc.
+# Full documentation: https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end
+on-run-end:
+  - '{{ save_test_results(results) }}'
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To update this repo, you will need write access to the General Mills public repo
 - [smart_source](#smart_source) [(source)](./macros/smart_source.sql)
 - [materialized_views](#materialized_views) [(source)](./macros/bigquery)
 - [save_test_results](#save_test_results) [(source)](./macros/save_test_results.sql)
-   - uses helper macro [generate_schema_name](#generate_schema_name) [(source)](./macros/helpers/generate_schema_name.sql)
+   - uses macros [generate_schema_name](#generate_schema_name) [(source)](./macros/generate_schema_name.sql) and `get_full_model_name` [source](./macros/helpers/generate_schema_name.sql)
 
 
 ### Usage 

--- a/README.md
+++ b/README.md
@@ -94,5 +94,5 @@ To use this macro within a project, include the following in the `dbt_project.ym
 # SQL statements to be executed after the completion of a run, build, test, etc.
 # Full documentation: https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end
 on-run-end:
-  - '{{ save_test_results(results) }}'
+  - '{{ gmi_common_dbt_utils.save_test_results(results) }}'
 ```

--- a/macros/helpers/_get_full_model_name.sql
+++ b/macros/helpers/_get_full_model_name.sql
@@ -1,0 +1,14 @@
+{%- macro _get_full_model_name(node_id) -%}
+    {%- set node_list = [] -%}
+    {%- if node_id.split('.')[0] == 'model' -%}
+        {%- set node_list = graph.nodes.values() | selectattr("resource_type", "equalto", "model") -%}
+    {%- elif node_id.split('.')[0] == 'source' -%}
+        {% set node_list = graph.sources.values() -%}
+    {%- endif -%}
+
+    {%- for node in node_list -%}
+        {%- if node.unique_id == node_id -%}
+            `{{ node.database }}.{{ node.schema }}.{{ node.name }}`
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}

--- a/macros/helpers/get_full_model_name.sql
+++ b/macros/helpers/get_full_model_name.sql
@@ -1,4 +1,4 @@
-{%- macro _get_full_model_name(node_id) -%}
+{%- macro get_full_model_name(node_id) -%}
     {%- set node_list = [] -%}
     {%- if node_id.split('.')[0] == 'model' -%}
         {%- set node_list = graph.nodes.values() | selectattr("resource_type", "equalto", "model") -%}

--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -9,7 +9,7 @@
 {%- endfor -%}
 
 {%- set results_tbl -%}
-    `{{ target.database }}.{{ generate_schema_name('processed') }}.dbt_test_results`
+    `{{ target.database }}.{{ gmi_common_dbt_utils.generate_schema_name('processed') }}.dbt_test_results`
 {%- endset -%}
 
 {{ log('Centralizing test data in ' + results_tbl, info = true) if execute }}
@@ -42,7 +42,7 @@ cluster by dbt_cloud_run_id
                 '{{ result.node.config.severity }}' as test_severity,
                 '{{ result.status }}' as test_result,
                 '{% for node_id in result.node.depends_on.nodes -%}
-                    {{ _get_full_model_name(node_id) }}
+                    {{ gmi_common_dbt_utils._get_full_model_name(node_id) }}
                     {%- if not loop.last -%},{%- endif -%}
                 {%- endfor %}' as test_models,
                 '{{ result.execution_time }}' as execution_time_seconds,

--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -42,7 +42,7 @@ cluster by dbt_cloud_run_id
                 '{{ result.node.config.severity }}' as test_severity,
                 '{{ result.status }}' as test_result,
                 '{% for node_id in result.node.depends_on.nodes -%}
-                    {{ gmi_common_dbt_utils._get_full_model_name(node_id) }}
+                    {{ gmi_common_dbt_utils.get_full_model_name(node_id) }}
                     {%- if not loop.last -%},{%- endif -%}
                 {%- endfor %}' as test_models,
                 '{{ result.execution_time }}' as execution_time_seconds,

--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -42,7 +42,7 @@ cluster by dbt_cloud_run_id
                 '{{ result.node.config.severity }}' as test_severity,
                 '{{ result.status }}' as test_result,
                 '{% for node_id in result.node.depends_on.nodes -%}
-                    {{ get_full_model_name(node_id) }}
+                    {{ _get_full_model_name(node_id) }}
                     {%- if not loop.last -%},{%- endif -%}
                 {%- endfor %}' as test_models,
                 '{{ result.execution_time }}' as execution_time_seconds,

--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -1,0 +1,56 @@
+{% macro save_test_results(results) %}
+
+{%- set test_results = [] -%}
+
+{%- for result in results -%}
+    {%- if result.node.resource_type == 'test' -%}
+        {%- do test_results.append(result) -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- set results_tbl -%}
+    `{{ target.database }}.{{ generate_schema_name('processed') }}.dbt_test_results`
+{%- endset -%}
+
+{{ log('Centralizing test data in ' + results_tbl, info = true) if execute }}
+
+create table if not exists {{ results_tbl }} (
+    test_id string,
+    test_name string,
+    project_name string,
+    target_db string,
+    dbt_run_env string,
+    test_severity string,
+    test_result string,
+    test_models string,
+    execution_time_seconds string,
+    dbt_cloud_run_id string,
+    create_update_ts timestamp
+)
+cluster by dbt_cloud_run_id
+;
+
+insert into {{ results_tbl }} (
+
+    {% for result in test_results %}
+        select
+            '{{ result.node.unique_id }}' as test_id,
+            '{{ result.node.name }}' as test_name,
+            '{{ project_name }}' as project_name,
+            '{{ target.database }}' as target_db,
+            '{{ env_var("DBT_RUN_ENV") }}' as dbt_run_env,
+            '{{ result.node.config.severity }}' as test_severity,
+            '{{ result.status }}' as test_result,
+            '{% for node_id in result.node.depends_on.nodes -%}
+                {{ get_full_model_name(node_id) }}
+                {%- if not loop.last -%},{%- endif -%}
+            {%- endfor %}' as test_models,
+            '{{ result.execution_time }}' as execution_time_seconds,
+            '{{ env_var("DBT_CLOUD_RUN_ID", invocation_id) }}' as dbt_cloud_run_id,
+            current_timestamp() as create_update_ts
+
+        {{ 'union all' if not loop.last }}
+    {% endfor %}
+);
+
+{% endmacro %}

--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -42,7 +42,7 @@ insert into {{ results_tbl }} (
             '{{ result.node.config.severity }}' as test_severity,
             '{{ result.status }}' as test_result,
             '{% for node_id in result.node.depends_on.nodes -%}
-                {{ get_full_model_name(node_id) }}
+                {{ _get_full_model_name(node_id) }}
                 {%- if not loop.last -%},{%- endif -%}
             {%- endfor %}' as test_models,
             '{{ result.execution_time }}' as execution_time_seconds,


### PR DESCRIPTION
### Changes
- Added `save_test_results` macro, which saves dbt test results after a `dbt build` or `dbt test` command was run via CLI or a dbt Cloud job.
- Added helper macro `get_full_model_name` to pull fully qualified table names of the models being tested, which is stored in the dbt test results table. These table names can be passed as a parameter to the DQ Metastore

### Testing
All testing took place in the SRM Kroger Engine: 
- Ran multiple variations of `dbt build` and `dbt test` via the dbt Cloud CLI, which successfully created & populated `zdev00_processed.dbt_test_results`
- Ran dbt Cloud jobs via Airflow dev and the dbt interface, which successfully created & populated `processed.dbt_test_results`
   - Link to dev Airflow test: [link](https://b699fdfd68eb44ba99f51a726e60381c-dot-us-central1.composer.googleusercontent.com/graph?dag_id=srm_kr_ai_dbt_test_dq_metastore&root=&execution_date=2022-10-12T20%3A35%3A47.507610%2B00%3A00)