### PR TITLE
Add columns to the save_test_results macro

### DIFF
--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -69,7 +69,7 @@ add column if not exists file_test_defined string
                 {%- endfor %}' as test_models,
                 '{{ result.execution_time }}' as execution_time_seconds,
                 '{{ env_var("DBT_CLOUD_RUN_ID", invocation_id) }}' as dbt_cloud_run_id,
-                current_timestamp() as create_update_ts.
+                current_timestamp() as create_update_ts,
                 '{{ test_short_name }}' as test_short_name,
                 '{{ test_type }}' as test_type,
                 '{{ result.node.original_file_path }}' as file_test_defined

--- a/macros/save_test_results.sql
+++ b/macros/save_test_results.sql
@@ -30,9 +30,31 @@ create table if not exists {{ results_tbl }} (
 cluster by dbt_cloud_run_id
 ;
 
+-- alter statements allow backward compatibility
+alter table {{ results_tbl }}
+add column if not exists test_short_name string
+;
+alter table {{ results_tbl }}
+add column if not exists test_type string
+;
+alter table {{ results_tbl }}
+add column if not exists file_test_defined string
+;
+
 {% if test_results|length > 0 %}
     insert into {{ results_tbl }} (
         {% for result in test_results %}
+
+            {%- set test_short_name='' -%}
+            {%- set test_type='' -%}
+            {%- if result.node.test_metadata is defined -%}
+                {%- set test_short_name = result.node.test_metadata.name -%}
+                {%- set test_type='generic' -%}
+            {%- elif result.node.name is defined -%}
+                {%- set test_short_name = result.node.name -%}
+                {%- set test_type='singular' -%}
+            {%- endif -%}
+
             select
                 '{{ result.node.unique_id }}' as test_id,
                 '{{ result.node.name }}' as test_name,
@@ -47,7 +69,10 @@ cluster by dbt_cloud_run_id
                 {%- endfor %}' as test_models,
                 '{{ result.execution_time }}' as execution_time_seconds,
                 '{{ env_var("DBT_CLOUD_RUN_ID", invocation_id) }}' as dbt_cloud_run_id,
-                current_timestamp() as create_update_ts
+                current_timestamp() as create_update_ts.
+                '{{ test_short_name }}' as test_short_name,
+                '{{ test_type }}' as test_type,
+                '{{ result.node.original_file_path }}' as file_test_defined
             {{ 'union all' if not loop.last }}
         {% endfor %}
     );


### PR DESCRIPTION
### Changes
Added 3 new columns to the `dbt_test_results` table, which are based off the following `store_test_results` macro: https://github.com/matt-winkler/dbt_workspace/blob/master/dbt/macros/test_analytics/store_test_results.sql
- `test_short_name` -> Simple name of the test. Unlike `test_name`, this column is not dependent on what data model the test is being run against. Example values: `unique`, `not_null`
- `test_type` -> `generic` or `singular`
- `file_test_defined` -> file path in the dbt project where the test was defined

### Testing
All testing was done in the SRM Kroger dbt project.

Scenario 1: No existing `dbt_test_results` table:
- The `dbt_test_results` table was successfully created with the new columns, and those columns were populated.

Scenario 2: Existing `dbt_test_results` table without the new columns:
- The `dbt_test_results` table was altered to include the new columns, and those columns were populated for new tests only.

#### Testing Screenshots
Schema

![image](https://user-images.githubusercontent.com/106691724/200036508-44c593be-4085-4467-840f-f4dc1bd056e2.png)

Data for scenario 1
![image](https://user-images.githubusercontent.com/106691724/200036941-1d9b8662-a8de-4325-91b6-3e2894fe76a7.png)

Data for scenario 2
![image](https://user-images.githubusercontent.com/106691724/200038856-206dc697-68b0-4a7d-abd1-6780dd3727e5.png)
